### PR TITLE
Update Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-bitarray = "*"
+bitarray = "1.4.2"
 
 [dev-packages]
 


### PR DESCRIPTION
Future versions of bitarray don't have the .length method, so the code breaks.